### PR TITLE
Add Cards and Typography own elements

### DIFF
--- a/src/components/UI/Typography/Typography.module.css
+++ b/src/components/UI/Typography/Typography.module.css
@@ -1,0 +1,27 @@
+.h1 {
+    font-size: clamp(2.488rem, 0.3578rem + 2.9358vw, 4.209rem);
+}
+
+.h2 {
+    font-size: clamp(2.074rem, 0.3578rem + 2.9358vw, 3.157rem);
+}
+
+.h3 {
+    font-size: clamp(1.728rem, 0.3578rem + 2.9358vw, 2.369rem);
+}
+
+.h4 {
+    font-size: clamp(1.44rem, 0.3578rem + 2.9358vw, 1.777rem);
+}
+
+.h5 {
+    font-size: clamp(1.2rem, 0.3578rem + 2.9358vw, 1.333rem);
+}
+
+.p {
+    font-size: clamp(1rem, 0.3578rem + 2.9358vw, 1.333rem);
+}
+
+.span {
+    font-size: 1rem;
+}

--- a/src/components/UI/Typography/Typography.tsx
+++ b/src/components/UI/Typography/Typography.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styles from './Typography.module.css';
+
+const classNames = {
+  h1: styles.h1,
+  h2: styles.h2,
+  h3: styles.h3,
+  h4: styles.h4,
+  h5: styles.h5,
+  p: styles.p,
+  span: styles.span
+};
+
+type TypographyProps = {
+  as: keyof typeof classNames;
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const Typography: React.FC<TypographyProps> = ({ as, children, className, ...props }) => {
+  const Tag = as;
+  const classNameTag = classNames[as];
+
+  return <Tag className={`${classNameTag} ${className}`} {...props}>{children}</Tag>;
+};

--- a/src/components/UI/Typography/index.ts
+++ b/src/components/UI/Typography/index.ts
@@ -1,0 +1,1 @@
+export { Typography } from './Typography';

--- a/src/components/cards/card.tsx
+++ b/src/components/cards/card.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import styles from './cards.module.css';
+
+type Card = {
+    children: React.ReactNode;
+    className?: string;
+};
+
+export const Card: React.FC<Card> = ({ children, className, ...props }) => {
+    return <div className={`${styles.cards} ${className}`} {...props}>{children}</div>;
+};

--- a/src/components/cards/cards.module.css
+++ b/src/components/cards/cards.module.css
@@ -1,0 +1,24 @@
+.titleCard {
+    padding: 1rem;
+    text-align: center;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.cards {
+    margin: 0 15vw;
+    text-align: center;
+    padding: 1rem 2rem;
+    background-color: var(--card-bgc);
+}
+
+.imageCards {
+    display: flex;
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+    margin-left: 15vw;
+    margin-right: 15vw;
+    margin-top: 5vh;
+    margin-bottom: 5vh;
+}

--- a/src/components/cards/imageCards.tsx
+++ b/src/components/cards/imageCards.tsx
@@ -1,27 +1,17 @@
-import { Box } from "@mui/material";
 import Image from "next/image";
+import styles from './cards.module.css';
 
 const ImageCards = (props: { image: string; description: string }) => {
   return (
-    <Box
-      style={{
-        display: "flex",
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-        marginLeft: "15vw",
-        marginRight: "15vw",
-        marginTop: "5vh",
-        marginBottom: "5vh",
-      }}
-    >
+    <div className={styles.imageCards}>
       <Image
         src={props.image || "/tomb2.jpg"}
         alt={props.description || "example description"}
         width={200}
         height={200}
       />
-    </Box>
+
+    </div>
   );
 };
 

--- a/src/components/cards/scriptureCards.tsx
+++ b/src/components/cards/scriptureCards.tsx
@@ -1,19 +1,18 @@
-import { Card, CardContent, Typography } from "@mui/material";
+import { Card } from "./card";
+import { Typography } from '../UI/Typography';
 
 const ScriptureCards = (props: { name: string; passage: string }) => {
   return (
-    <Card sx={{ ml: "15vw", mr: "15vw" }}>
+    <Card>
       <Typography
-        variant="h3"
-        style={{ marginTop: "5vh", textAlign: "center" }}
+        as="h3"
       >
         {props.name}
       </Typography>
-      <CardContent>
-        <Typography variant="h5" style={{ textAlign: "center" }}>
-          {props.passage}
-        </Typography>
-      </CardContent>
+      <Typography as="p"
+      >
+        {props.passage}
+      </Typography>
     </Card>
   );
 };

--- a/src/components/cards/titleCard.tsx
+++ b/src/components/cards/titleCard.tsx
@@ -1,14 +1,12 @@
-import { Card, CardContent, Typography } from "@mui/material";
+import { Typography } from '../UI/Typography/Typography';
+import { Card } from './card';
+import styles from './cards.module.css';
 
 const TitleCard = (props: { title: string }) => {
   return (
-    <Card sx={{ ml: "15vw", mr: "15vw" }}>
-      <CardContent>
-        <Typography variant="h3" style={{ textAlign: "center" }}>
-          {props.title}
-        </Typography>
-      </CardContent>
+    <Card>
+      <Typography as="h2" className={styles.titleCard}>{props.title}</Typography>
     </Card>
-  );
+  )
 };
 export default TitleCard;

--- a/src/pages/globals.css
+++ b/src/pages/globals.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css?family=Poppins:400,500');
+
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
@@ -37,6 +39,7 @@
   --callout-rgb: 238, 240, 241;
   --callout-border-rgb: 172, 175, 176;
   --card-rgb: 180, 185, 188;
+  --card-bgc: #1e1e1e;
   --card-border-rgb: 131, 134, 135;
 }
 
@@ -105,3 +108,36 @@ a {
     color-scheme: dark;
   }
 }
+
+
+html {font-size: 100%;} /*16px*/
+
+body {
+  font-family: 'Poppins', sans-serif;
+  font-weight: 400;
+  line-height: 1.75;
+}
+
+p {margin-bottom: 1rem;}
+
+h1, h2, h3, h4, h5 {
+  margin: 1rem 0 1rem  ;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 2.488rem;
+}
+
+h2 {font-size: 2.074rem;}
+
+h3 {font-size: 1.728rem;}
+
+h4 {font-size: 1.44rem;}
+
+h5 {font-size: 1.2rem;}
+
+small, .text_small {font-size: 0.833rem;}

--- a/src/pages/workflow/accuracy.tsx
+++ b/src/pages/workflow/accuracy.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import WorkflowLayout from "./layout";
 import axios from "axios";
 import AccuracyButton from "@/components/accuracyChecker/accuracyButton";
-import BottomNav from "@/components/menus/bottomNav";
 import PageNav from "@/components/menus/pageNav";
 import ScriptureCards from "@/components/cards/scriptureCards";
 import ImageCards from "@/components/cards/imageCards";

--- a/src/pages/workflow/finalize.tsx
+++ b/src/pages/workflow/finalize.tsx
@@ -15,7 +15,6 @@ import {
 import React, { useEffect } from "react";
 import WorkflowLayout from './layout';
 import axios from "axios";
-import BottomNav from "@/components/menus/bottomNav";
 import TitleCard from "@/components/cards/titleCard";
 
 interface JSONData {

--- a/src/pages/workflow/learn.tsx
+++ b/src/pages/workflow/learn.tsx
@@ -4,7 +4,6 @@ import WorkflowLayout from './layout';
 import axios from "axios";
 import ReactPlayer from "react-player";
 import DOMPurify from "dompurify";
-import BottomNav from "@/components/menus/bottomNav";
 import TitleCard from "@/components/cards/titleCard";
 
 interface JSONData {

--- a/src/pages/workflow/naturalness.tsx
+++ b/src/pages/workflow/naturalness.tsx
@@ -2,7 +2,6 @@ import { Box, Button, Card, CardContent, Typography } from "@mui/material";
 import React, { useEffect } from "react";
 import WorkflowLayout from "./layout";
 import axios from "axios";
-import BottomNav from "@/components/menus/bottomNav";
 import PageNav from "@/components/menus/pageNav";
 import ScriptureCards from "@/components/cards/scriptureCards";
 import ImageCards from "@/components/cards/imageCards";

--- a/src/pages/workflow/translate.tsx
+++ b/src/pages/workflow/translate.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from "react";
 import WorkflowLayout from "./layout";
 import axios from "axios";
 import { AudioRecorder } from "react-audio-voice-recorder";
-import BottomNav from "@/components/menus/bottomNav";
 import PageNav from "@/components/menus/pageNav";
 import ScriptureCards from "@/components/cards/scriptureCards";
 import ImageCards from "@/components/cards/imageCards";

--- a/src/pages/workflow/voice.tsx
+++ b/src/pages/workflow/voice.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import WorkflowLayout from "./layout";
 import axios from "axios";
-import BottomNav from "@/components/menus/bottomNav";
 import PageNav from "@/components/menus/pageNav";
 import ScriptureCards from "@/components/cards/scriptureCards";
 import ImageCards from "@/components/cards/imageCards";


### PR DESCRIPTION
Add Cards and Typography own elements:

Typography, now we use fluid-size text (on the workflow pages, but the plan is using it on all the project)
Change the card elements to own components. 